### PR TITLE
LiSa improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ web_frontend/build
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# data directory
+data/db/*
+data/storage/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - worker
     networks:
       lisanet:
-        ipv4_address: 172.42.0.10
+        ipv4_address: 172.42.0.20
     restart: on-failure
 
   worker:
@@ -47,7 +47,7 @@ services:
       - api
     networks:
       lisanet:
-        ipv4_address: 172.42.0.12
+        ipv4_address: 172.42.0.22
 
   rabbitmq:
     image: rabbitmq:latest
@@ -58,7 +58,7 @@ services:
       - 5672:5672
     networks:
       lisanet:
-        ipv4_address: 172.42.0.13
+        ipv4_address: 172.42.0.23
 
   mariadb:
     image: mariadb:latest
@@ -72,7 +72,7 @@ services:
       - "./data/db:/var/lib/mysql"
     networks:
       lisanet:
-        ipv4_address: 172.42.0.14
+        ipv4_address: 172.42.0.24
     restart: always
 
 networks:

--- a/lisa/analysis/static_analysis.py
+++ b/lisa/analysis/static_analysis.py
@@ -59,8 +59,8 @@ class StaticAnalyzer(AbstractSubAnalyzer):
             'language': info['bin']['lang'],
             'stripped': info['bin']['stripped'],
             'relocations': info['bin']['relocs'],
-            'min_opsize': info['bin']['minopsz'],
-            'max_opsize': info['bin']['maxopsz'],
+            'min_opsize': info['core']['minopsz'],
+            'max_opsize': info['core']['maxopsz'],
             'entry_point': entry_point[0]['vaddr']
         }
 

--- a/lisa/config.py
+++ b/lisa/config.py
@@ -76,6 +76,6 @@ logging_config = {
     }
 }
 
-celery_broker = 'pyamqp://lisa:lisa@172.42.0.13//'
-celery_backend = 'db+mysql+pymysql://lisa:lisa@172.42.0.14/lisadb'
-sql_backend = 'mysql+pymysql://lisa:lisa@172.42.0.14/lisadb'
+celery_broker = 'pyamqp://lisa:lisa@172.42.0.23//'
+celery_backend = 'db+mysql+pymysql://lisa:lisa@172.42.0.24/lisadb'
+sql_backend = 'mysql+pymysql://lisa:lisa@172.42.0.24/lisadb'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pexpect==4.2.1
 geoip2==2.9.0
 flask==1.0.2
 flask-cors===3.0.9
-celery==5.2.2
+celery==5.1.2
 rabbitmq==0.2.0
 sqlalchemy==1.3.0
 pymysql==0.9.3


### PR DESCRIPTION
## CHANGES

+ Change the IP range of the services from 172.42.0.1x to 172.42.0.2x. If you started more than 9 workers at the same time the IPs overlapped. Now it's possible to start more than 9 workers at the same time (up to 19 workers).  

+ New flag (--packet-buffered) added to tcpdump. With this flag each captured packet will be written to the output file, rather than being written only when the output buffer fills.

+ Function send_command (qemu_guest.py) changed. Some architectures (m68k, sh4...) do not support commands with more than 16 digits. The command will be splitted in smaller chunks in order to be processed properly by QEMU.

+ #24 

+ Git ignore data/storage and data/db files