### PR TITLE
Updates for r2 and celery version correction. 

### DIFF
--- a/lisa/analysis/static_analysis.py
+++ b/lisa/analysis/static_analysis.py
@@ -59,8 +59,8 @@ class StaticAnalyzer(AbstractSubAnalyzer):
             'language': info['bin']['lang'],
             'stripped': info['bin']['stripped'],
             'relocations': info['bin']['relocs'],
-            'min_opsize': info['bin']['minopsz'],
-            'max_opsize': info['bin']['maxopsz'],
+            'min_opsize': info['core']['minopsz'],
+            'max_opsize': info['core']['maxopsz'],
             'entry_point': entry_point[0]['vaddr']
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pexpect==4.2.1
 geoip2==2.9.0
 flask==1.0.2
 flask-cors===3.0.9
-celery==5.2.2
+celery==5.1.2
 rabbitmq==0.2.0
 sqlalchemy==1.3.0
 pymysql==0.9.3


### PR DESCRIPTION

The docker files are set for python:3.6-slim. 
Celery -  Python 3.6: Celery 5.1 or earlier. 

I tested with python:3.7 and ran into more errors and dep issues.
 
build with no errors and tested with the test file testbin-puts-mips


```
> docker-compose exec worker bash
root@6b2c045eb59c:/home/lisa# r2 -V
5.6.4  r2
5.6.4  r_anal
5.6.4  r_lib
5.6.4  r_egg
5.6.4  r_asm
5.6.4  r_bin
5.6.4  r_cons
5.6.4  r_flag
5.6.4  r_core
5.6.4  r_crypto
5.6.4  r_bp
5.6.4  r_debug
5.6.4  r_main
5.6.4  r_hash
5.6.4  r_fs
5.6.4  r_io
5.6.4  r_magic
5.6.4  r_parse
5.6.4  r_reg
5.6.4  r_sign
5.6.4  r_search
5.6.4  r_syscall
5.6.4  r_util

root@6b2c045eb59c:/home/lisa# celery --version
5.1.2 (sun-harmonics)
root@6b2c045eb59c:/home/lisa#
```